### PR TITLE
Fix network_interface_info module

### DIFF
--- a/plugins/modules/network_interface_info.py
+++ b/plugins/modules/network_interface_info.py
@@ -133,7 +133,7 @@ from ..module_utils.machine import Machine
 
 
 def run(module, client):
-    machine_obj = Machine.get_by_fqdn(module, client, must_exist=True)
+    machine_obj = Machine.get_by_fqdn(module, client, must_exist=True, name_field_ansible="machine")
     if module.params["mac_address"]:
         nic_obj = machine_obj.find_nic_by_mac(module.params["mac_address"])
         if nic_obj:

--- a/plugins/modules/network_interface_info.py
+++ b/plugins/modules/network_interface_info.py
@@ -133,7 +133,9 @@ from ..module_utils.machine import Machine
 
 
 def run(module, client):
-    machine_obj = Machine.get_by_fqdn(module, client, must_exist=True, name_field_ansible="machine")
+    machine_obj = Machine.get_by_fqdn(
+        module, client, must_exist=True, name_field_ansible="machine"
+    )
     if module.params["mac_address"]:
         nic_obj = machine_obj.find_nic_by_mac(module.params["mac_address"])
         if nic_obj:


### PR DESCRIPTION
This module accepts only `machine` and `mac_address` parameter.
Network_interface_info module calls `/MAAS/api/2.0/machines/` API with `fqdn` query parameter.
To transform `machine` to `fqdn`, specifing name_field_ansible opt.

https://github.com/canonical/ansible-collection/blob/7bb2a1b23ab8c3f267f40832dc76ddf50f2cbbe0/plugins/modules/network_interface_info.py#L136


## Checklist before merging
- [ ] Formatting: `tox -e format`
- [ ] Linting: `tox -e sanity`
- [ ] Unit tests: `tox -e units`
